### PR TITLE
Update to vfs 0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/Berrysoft/vfs-tar"
 [dependencies]
 tar-parser2 = "0.9"
 stable_deref_trait = "1.2"
-vfs = "0.10"
+vfs = "0.12"
 memmap2 = { version = "0.9", optional = true, features = [
     "stable_deref_trait",
 ] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 #![warn(missing_docs)]
 
 use stable_deref_trait::StableDeref;
+use std::time::SystemTime;
 #[allow(unused_imports)]
 use std::{
     borrow::Cow,
@@ -13,7 +14,6 @@ use std::{
     ops::Deref,
     path::{Iter, Path},
 };
-use std::time::SystemTime;
 use tar_parser2::*;
 use vfs::{error::VfsErrorKind, *};
 
@@ -158,25 +158,25 @@ impl<F: StableDeref<Target = [u8]> + Debug + Send + Sync + 'static> FileSystem f
         match self.find_entry(path) {
             Some(e) => {
                 //FIXME get mtime from Header also ctime atime from Pax Headers
-                let modified=Some(SystemTime::UNIX_EPOCH);
+                let modified = Some(SystemTime::UNIX_EPOCH);
                 match e {
                     EntryRef::File(buf) => Ok(VfsMetadata {
                         file_type: VfsFileType::File,
                         len: buf.len() as u64,
                         created: None,
                         modified,
-                        accessed: None
+                        accessed: None,
                     }),
                     EntryRef::Directory(_) => Ok(VfsMetadata {
                         file_type: VfsFileType::Directory,
                         len: 0,
                         created: None,
                         modified,
-                        accessed: None
+                        accessed: None,
                     }),
                     EntryRef::Link(_) => unreachable!(),
                 }
-            },
+            }
             None => Err(VfsErrorKind::FileNotFound.into()),
         }
     }


### PR DESCRIPTION
Just one small thing left to do, add the metadata for mtime, atime and ctime

```
     Running unittests src/lib.rs (target/debug/deps/vfs_tar-1dc0a0c78b239662)

running 4 tests
test test::basic ... ok
test test::long ... ok
test test::ustar ... ok
test test::link ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

```